### PR TITLE
Set plugin to require restart after installation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Updated to require restart after installation.
+
+### Added
+
 - Added an option to disable the plugin for large files.
 - Added service optimizations for performance gains.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.github.jdha.brackets
 pluginName=brackets
 pluginRepositoryUrl=https://github.com/j-d-ha/brackets
 # SemVer format -> https://semver.org
-pluginVersion=0.0.2
+pluginVersion=0.0.3
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=233
 #pluginUntilBuild=

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
 -->
 
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
-<idea-plugin>
+<idea-plugin require-restart="true">
     <id>com.github.jdha.brackets</id>
     <name>brackets</name>
     <vendor>j-d-ha</vendor>


### PR DESCRIPTION
Added the `require-restart` attribute in the plugin configuration file to ensure proper initialization after installation. Updated the changelog to reflect this change for better transparency.